### PR TITLE
User Story 4 - Voir le feux orange avant le passage au rouge

### DIFF
--- a/Network.js
+++ b/Network.js
@@ -12,5 +12,8 @@ class Network {
 		return this.trafficLights.filter(tl => tl.status === color)
 			.map(tl => tl.name)
 	}
+	getTrafficLightByName(name) {
+		return this.trafficLights.find(tl => tl.name === name)
+	}
 }
 const PomPomGaly = new Network()

--- a/README.md
+++ b/README.md
@@ -29,19 +29,5 @@ Notes :
 - Ajouter une méthode **listGreenTrafficLight()**
 - Notions : class, new, localStorage, .filter(), .map()
 
-### User Story 4 - Voir le feux orange avant le passage au rouge
-
-En tant que conducteur je souhaite être averti que le feux va passer au rouge afin de ne pas freiner trop brusquement.
-
-- doit permettre d'ajouter un statut orange avant le passage au rouge
-- doit rester 10" au orange avant de passer au rouge
-
-Notes :
-- Ajouter une **méthode changeToOrange()** dans la classe **Feux**
-- Regarder l'utilisation de **setTimer()** et **setInterval()** pour résoudre le problème des 10"
-- Appeler la nouvelle méthode dans **changeToRed()**
-- Tester la méthode
-- Notions : class, new, localStorage, .filter(), .map()
-
 
 

--- a/TrafficLight.js
+++ b/TrafficLight.js
@@ -4,7 +4,12 @@ class TrafficLight {
 		this.location = location
 		this.status = 'vert'
 	}
+	_changeStatus(color) {
+		this.status = color
+		console.log(`Le feu ${this.name} est ${this.status}`)
+	}
 	changeToRed() {
-		this.status = 'rouge'
+		this._changeStatus('orange')
+		setTimeout(() => this._changeStatus('rouge'), 3000)
 	}
 }


### PR DESCRIPTION
### User Story 4 - Voir le feux orange avant le passage au rouge

En tant que conducteur je souhaite être averti que le feu va passer au rouge afin de ne pas freiner trop brusquement.

[x] - doit permettre d'ajouter un statut orange avant le passage au rouge
[x] - doit rester 3" au orange avant de passer au rouge
[x] - ne doit pas passer au orange si le feu est déjà rouge
[x] - doit afficher tous les changements de statut dans la console 

Notes :
- Ajouter le statut _orange_ dans la méthode **changeToRed()** 
- Regarder l'utilisation de **setTimout()** et **setInterval()** pour résoudre le problème du temps
- Tester la méthode
- Ajouter une méthode **changeStatus(color)** pour changer le status
- loguer tous les changements dans la console
- Notions : new, .find(), `${}`, console.log(), this, _ (methode privé), setTimeout
